### PR TITLE
Added html parsing for section and card input fields

### DIFF
--- a/components/Dashboard/Proposal/Board/card.js
+++ b/components/Dashboard/Proposal/Board/card.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import ReactHtmlParser from 'react-html-parser';
 import { Container, Draggable } from 'react-smooth-dnd';
 
 import { StyledCard } from './styles';
@@ -34,7 +35,7 @@ class Card extends Component {
           }}
         >
           <div className="card-drag-handle">
-            <h4>{card.title}</h4>
+            <h4>{ReactHtmlParser(card.title)}</h4>
             {!proposalBuildMode && (
               <div className="card-information">
                 <div className="info-assigned-container">

--- a/components/Dashboard/Proposal/Board/section.js
+++ b/components/Dashboard/Proposal/Board/section.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import ReactHTMLParser from 'react-html-parser';
 import { gql, useMutation } from '@apollo/client';
 import sortBy from 'lodash/sortBy';
 import { Container, Draggable } from 'react-smooth-dnd';
@@ -334,7 +335,7 @@ const Section = ({
   return (
     <StyledSection>
       <div className="column-drag-handle">
-        <h3>{section.title}</h3>
+        <h3>{ReactHTMLParser(section.title)}</h3>
         <span>
           {numOfCards} card{numOfCards <= 1 ? '' : 's'}
         </span>


### PR DESCRIPTION
Lucy mentioned that it would be good to be able to input HTML for sections and for the individual cards. The property of card/section being converted to html is called 'title', which may no longer be appropriate.