### PR TITLE
added feedback when link is copied in study builder

### DIFF
--- a/components/Development/Study/StudyBuilder/Edit/editBasic.js
+++ b/components/Development/Study/StudyBuilder/Edit/editBasic.js
@@ -36,6 +36,7 @@ class EditBasic extends Component {
     temp.select();
     document.execCommand('copy');
     temp.remove();
+    alert('The link is copied');
   };
 
   render() {


### PR DESCRIPTION
I used the same 'alert' solution as in other parts of the site where links are copied.