### PR TITLE
proceedToFirstTask parameter set to true on creation

### DIFF
--- a/components/Development/selectScreen.js
+++ b/components/Development/selectScreen.js
@@ -272,7 +272,7 @@ class DevelopmentSelectScreen extends Component {
                 settings: {
                   consentObtained: false,
                   guestParticipation: true,
-                  proceedToFirstTask: false,
+                  proceedToFirstTask: true,
                   zipCode: false,
                   sonaId: false,
                   minorsBlocked: false,


### PR DESCRIPTION
Changed the Parameter check box in the study builder, so that "After joining the study..." is already checked upon creation.