### PR TITLE
changed card modal to be scrollable

### DIFF
--- a/components/Dashboard/Proposal/Card/modal.js
+++ b/components/Dashboard/Proposal/Card/modal.js
@@ -168,7 +168,7 @@ class CardModal extends Component {
         size="large"
         onClose={() => onClose()}
       >
-        <Modal.Content>
+        <Modal.Content scrolling>
           <Modal.Description>
             <Query query={GET_CARD_CONTENT} variables={{ id: cardId }}>
               {({ data, loading: queryLoading }) => {


### PR DESCRIPTION
Modal element is now set to be scrollable so the footer containing our close buttons remains fixed to the bottom of the viewport.