### PR TITLE
Proposal tags update

### DIFF
--- a/components/Dashboard/Jodit/Forms/statusForm.js
+++ b/components/Dashboard/Jodit/Forms/statusForm.js
@@ -25,17 +25,17 @@ const StyledDropdown = styled.div`
     color: #0063CE !important;
     background: rgba(0, 117, 224, 0.12) !important;
   }
-  .status-on-hold {
+  .status-needs-feedback {
     color: #C92927 !important;
     background: rgba(224, 103, 102, 0.12) !important;
+  }
+  .status-feedback-given {
+    color: #6F25CE !important;
+    background: rgba(111, 37, 206, 0.12) !important;
   }
   .status-completed {
     color: #00635A !important;
     background: rgba(0, 124, 112, 0.12) !important;
-  }
-  .status-closed {
-    color: #1A1A1A !important;
-    background: rgba(0, 0, 0, 0.12) !important;
   }
   .info-status :hover {
     background: #F7F7F7 !important;
@@ -63,22 +63,22 @@ class StatusForm extends Component {
         className: 'info-status status-started',
       },
       {
-        key: 'On hold',
-        text: 'On hold',
-        value: 'On hold',
-        className: 'info-status status-on-hold',
+        key: 'Needs feedback',
+        text: 'Needs feedback',
+        value: 'Needs feedback',
+        className: 'info-status status-needs-feedback',
+      },
+      {
+        key: 'Feedback given',
+        text: 'Feedback given',
+        value: 'Feedback given',
+        className: 'info-status status-feedback-given',
       },
       {
         key: 'Completed',
         text: 'Completed',
         value: 'Completed',
         className: 'info-status status-completed',
-      },
-      {
-        key: 'Closed',
-        text: 'Closed',
-        value: 'Closed',
-        className: 'info-status status-closed',
       }
     ];
 

--- a/components/Dashboard/Proposal/Board/card.js
+++ b/components/Dashboard/Proposal/Board/card.js
@@ -7,7 +7,7 @@ import { StyledCard } from './styles';
 class Card extends Component {
   render() {
     const { card, proposalBuildMode, adminMode } = this.props;
-    const status = card?.settings?.status? card.settings.status : 'Not started';
+    let status = card?.settings?.status? card.settings.status : 'Not started';
 
     let statusStyle = null;
     switch (status) {
@@ -25,6 +25,15 @@ class Card extends Component {
         break;
       case 'Completed':
         statusStyle = 'status-completed';
+        break;
+      // in case any cards are still tagged 'Closed' or 'On-Hold'
+      case 'Closed':
+        status = 'Started';
+        statusStyle = 'status-started';
+        break;
+      case 'On-Hold':
+        status = 'Needs feedback';
+        statusStyle = 'status-needs-feedback';
     }
 
     return (

--- a/components/Dashboard/Proposal/Board/card.js
+++ b/components/Dashboard/Proposal/Board/card.js
@@ -17,14 +17,14 @@ class Card extends Component {
       case 'Started':
         statusStyle = 'status-started';
         break;
-      case 'On-Hold':
-        statusStyle = 'status-on-hold';
+      case 'Needs feedback':
+        statusStyle = 'status-needs-feedback';
+        break;
+      case 'Feedback given':
+        statusStyle = 'status-feedback-given';
         break;
       case 'Completed':
         statusStyle = 'status-completed';
-        break;
-      case 'Closed':
-        statusStyle = 'status-closed';
     }
 
     return (

--- a/components/Dashboard/Proposal/Board/styles.js
+++ b/components/Dashboard/Proposal/Board/styles.js
@@ -156,17 +156,17 @@ export const StyledCard = styled.div`
       color: #0063CE;
       background: rgba(0, 117, 224, 0.12);
     }
-    .status-on-hold {
+    .status-needs-feedback {
       color: #C92927;
       background: rgba(224, 103, 102, 0.12);
+    }
+    .status-feedback-given {
+      color: #6F25CE !important;
+      background: rgba(111, 37, 206, 0.12) !important;
     }
     .status-completed {
       color: #00635A;
       background: rgba(0, 124, 112, 0.12);
-    }
-    .status-closed {
-      color: #1A1A1A;
-      background: rgba(0, 0, 0, 0.12);
     }
   }
 `;

--- a/components/Dashboard/Review/ReviewBoard/questions.js
+++ b/components/Dashboard/Review/ReviewBoard/questions.js
@@ -23,6 +23,14 @@ const StyledReviewQuestions = styled.div`
     letter-spacing: 0em;
     text-align: left;
   }
+  h2 {
+    font-family: Lato;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 700, Bold;
+    line-height: 24px;
+    margin-bottom: 0;
+  }
   p {
     font-family: Lato;
     font-size: 16px;
@@ -208,7 +216,7 @@ class ReviewQuestions extends Component {
     return (
       <StyledReviewQuestions>
         <>
-          <h1>Review questions</h1>
+          <h1>Synthesis questions</h1>
           <div className="reviewItems">
             {this.state.content.map((item, i) => (
               <SingleQuestion

--- a/components/Dashboard/Review/ReviewBoard/review.js
+++ b/components/Dashboard/Review/ReviewBoard/review.js
@@ -77,10 +77,8 @@ const StyledFullReviewContainer = styled.div`
       grid-template-columns: auto 1fr;
       grid-gap: 9px;
       background: #ffffff;
-      border: 1px solid #cccccc;
       box-sizing: border-box;
       border-radius: 4px;
-      padding: 15px;
       align-items: center;
     }
   }
@@ -290,6 +288,7 @@ class ReviewPage extends Component {
 
                             <Dropdown
                               fluid
+                              selection
                               defaultValue={this.state.view}
                               options={[
                                 {

--- a/components/Dashboard/Review/ReviewBoard/reviewQuestions.js
+++ b/components/Dashboard/Review/ReviewBoard/reviewQuestions.js
@@ -1,3 +1,5 @@
+import { PROPOSALS_FOR_REVIEW_QUERY } from "../reviews";
+
 export const individualQuestions = [
   {
     name: '1',
@@ -42,17 +44,21 @@ export const synthesisQuestions = [
   {
     name: '1',
     question: 'We learned',
+    text: 'Summarize the study and its goals in your own words. What did you find compelling? What did you learn about the human brain and behavior?',
   },
   {
     name: '2',
     question: 'We liked',
+    text: 'What stands out to you about this proposal? What resonates? What do you think is effective? Creative?',
   },
   {
     name: '3',
     question: 'We wished',
+    text: 'What do you think the scientist could think differently about? What’s not in the proposal that you might incorporate? What do you want to know more about?',
   },
   {
     name: '4',
     question: 'We wondered',
+    text: 'What is a suggestion you might make? (e.g., I wonder if the author might...) What might be the outcome of a slight tweak to the proposal?',
   },
 ];

--- a/components/Dashboard/Review/ReviewBoard/singleQuestion.js
+++ b/components/Dashboard/Review/ReviewBoard/singleQuestion.js
@@ -13,7 +13,8 @@ class SingleQuestion extends Component {
     return (
       <StyledReviewItem>
         <div>
-          <p>{item.question}</p>
+          <h2>{item.question}</h2>
+          <p>{item.text}</p>
         </div>
 
         {stage === 'INDIVIDUAL' && (


### PR DESCRIPTION
Changed the status options for proposal card tags. Existing 'Closed' tags display as 'Started', 'On hold' display as 'Needs feedback'.