### PR TITLE
fixed hanging text on review menu

### DIFF
--- a/components/Dashboard/Review/ReviewBoard/line.js
+++ b/components/Dashboard/Review/ReviewBoard/line.js
@@ -5,7 +5,7 @@ const StyledClassRow = styled.div`
   display: grid;
   margin: 5px;
   padding: 10px;
-  grid-template-columns: 300px 200px 120px 120px 200px;
+  grid-template-columns: 300px 200px 120px 120px 300px;
   grid-gap: 5px;
   background: white;
   .buttons {

--- a/components/Dashboard/Review/ReviewBoard/review.js
+++ b/components/Dashboard/Review/ReviewBoard/review.js
@@ -273,18 +273,8 @@ class ReviewPage extends Component {
                       {this.props.stage === 'SYNTHESIS' &&
                         this.state.tab === 'reviews' && (
                           <div className="headerRight">
-                            {this.state.view === 'byQuestion' && (
-                              <img
-                                width="20px"
-                                src="/static/assets/view-question.png"
-                              />
-                            )}
-                            {this.state.view === 'byReviewer' && (
-                              <img
-                                width="20px"
-                                src="/static/assets/view-reviewer.png"
-                              />
-                            )}
+                            {this.state.view === 'byQuestion'}
+                            {this.state.view === 'byReviewer'}
 
                             <Dropdown
                               fluid


### PR DESCRIPTION
The Review page menu bar had "synthesize" hanging off the white background, so I expanded the right-most in the grid. I also removed the icon from beside the dropdown on the Synthesis questions page. 