### PR TITLE
Participate filter

### DIFF
--- a/components/Bank/Studies/archiveDelete.js
+++ b/components/Bank/Studies/archiveDelete.js
@@ -61,9 +61,12 @@ function ArchiveModal({study, isHidden}) {
             <>
               <div className="heading">
                 <Icon name='archive' />
-                <span>Archive Study</span>
+                <span>{isHidden ? "Unarchive study" : "Archive Study"}</span>
               </div>
-              <p>Archiving a study moves it to the <br/>"Archived" section in your Develop <br/>area. It will not impact how others <br/>see the study.</p> 
+              {isHidden ? 
+                <p>Unarchiving a study will return it to<br/> the "Active" section in your develop<br/> area. It will not impact how others <br/>see the study</p>
+                : <p>Archiving a study moves it to the <br/>"Archived" section in your Develop <br/>area. It will not impact how others <br/>see the study.</p> 
+              }
             </>
           }
         />
@@ -72,8 +75,11 @@ function ArchiveModal({study, isHidden}) {
       <Modal.Content>
         <Modal.Description>
           <StyledModal>
-            <h3>Are you sure you want to <strong>archive</strong> this study?</h3>
-            <p>Archiving a study allows you to focus on active studies. The study will be moved to an "Archived" section within your Develop area. It will not impact how others see the study. You can unarchive a study at any time.</p>
+            <h3>Are you sure you want to <strong>{isHidden ? "unarchive" : "archive"}</strong> this study?</h3>
+            {isHidden ? 
+              <p>The study will be returned to the "Active" section within your Develop area. It will not impact how others see the study. You can rearchive a study at any time.</p>
+              : <p>Archiving a study allows you to focus on active studies. The study will be moved to an "Archived" section within your Develop area. It will not impact how others see the study. You can unarchive a study at any time.</p>
+            }
           </StyledModal>
         </Modal.Description>
       </Modal.Content>

--- a/components/Bank/Studies/developed.js
+++ b/components/Bank/Studies/developed.js
@@ -57,7 +57,7 @@ const filterOptions = [
 ];
 
 class DevelopedStudiesBank extends Component {
-  state= {
+  state = {
     filter: 'All'
   }
 

--- a/components/Bank/Studies/index.js
+++ b/components/Bank/Studies/index.js
@@ -1,12 +1,45 @@
 import React, { Component } from 'react';
 import { Query } from '@apollo/client/react/components';
+import { Dropdown } from 'semantic-ui-react';
 
-import { StyledBank } from '../styles';
+import { StyledBank, StyledDropdown } from '../styles';
 import StudyCard from './studycard';
+import ParticipatedStudiesBank from './participated';
 
 import { ALL_PUBLIC_STUDIES_QUERY } from '../../Queries/Study';
 
+const filterOptions = [
+  {
+    key: "All",
+    text: "All studies",
+    value: "All",
+    content: "All studies"
+  },
+  {
+    key: "Participated",
+    text: "Studies I participated in",
+    value: "Participated",
+    content: "Studies I participated in"
+  },
+  {
+    key: "Not participated",
+    text: "Studies I haven't participated in",
+    value: "Not participated",
+    content: "Studies I haven't participated in"
+  }
+];
+
 class StudiesBank extends Component {
+  state = {
+    filter: "All"
+  }
+
+  filterStudies = (event, data) => {
+    this.setState({
+      filter: data.value
+    })
+  }
+
   render() {
     return (
       <Query query={ALL_PUBLIC_STUDIES_QUERY}>
@@ -14,18 +47,48 @@ class StudiesBank extends Component {
           if (loading) return <></>;
           if (error) return <p>Error: {error?.message}</p>;
           const { studies } = data;
+
           return (
-            <StyledBank>
-              <div className="studies">
-                {studies.map(study => (
-                  <StudyCard
-                    key={study.id}
-                    study={study}
-                    onSelectStudy={this.props.onSelectStudy}
-                  />
-                ))}
-              </div>
-            </StyledBank>
+            <>
+
+              <StyledDropdown>
+                <Dropdown
+                  selection
+                  fluid
+                  value={this.state.filter}
+                  options={filterOptions}
+                  onChange={this.filterStudies}
+                />
+              </StyledDropdown>
+
+              {this.state.filter === "All" && (
+                <StyledBank>
+                  <div className="studies">
+                    {studies.map(study => (
+                      <StudyCard
+                        key={study.id}
+                        study={study}
+                        onSelectStudy={this.props.onSelectStudy}
+                      />
+                    ))}
+                  </div>
+                </StyledBank>
+              )}
+
+              {this.state.filter === "Participated" && (
+                <ParticipatedStudiesBank
+                  onSelectStudy={this.props.onSelectStudy}
+                />
+              )}
+
+              {this.state.filter === "Not participated" && (
+                <ParticipatedStudiesBank
+                  allStudies={studies}
+                  onSelectStudy={this.props.onSelectStudy}
+                />
+              )}
+
+            </>
           );
         }}
       </Query>

--- a/components/Bank/Studies/participated.js
+++ b/components/Bank/Studies/participated.js
@@ -70,10 +70,19 @@ class ParticipatedStudiesBank extends Component {
                 </StyledZeroState>
               );
             }
+            let filteredStudies = studies
+            let studiesIDsToHide = studies
+              .map(study => study.id);
+
+            if (this.props.allStudies) {
+              filteredStudies = this.props.allStudies.filter(
+                study => !studiesIDsToHide.includes(study?.id)
+              );
+            }
             return (
               <StyledBank>
                 <div className="studies">
-                  {studies.map(study => (
+                  {filteredStudies.map(study => (
                     <StudyCard
                       key={study.id}
                       study={study}

--- a/components/Bank/styles.js
+++ b/components/Bank/styles.js
@@ -7,9 +7,6 @@ export const StyledBank = styled.div`
 
 export const StyledDropdown = styled.div`
   display: grid;
-  .dropdown {
-    width: 220px;
-  }
   justify-content: end;
 `;
 

--- a/components/Nav/sidebar.js
+++ b/components/Nav/sidebar.js
@@ -98,7 +98,7 @@ const SidebarNav = ({ user }) => {
           </Link>
         )}
 
-        <Link href="/dashboard/participate">
+        {/* <Link href="/dashboard/participate">
           <NavLink selected={router.pathname === '/dashboard/participate'}>
             <div>
               <svg
@@ -120,7 +120,7 @@ const SidebarNav = ({ user }) => {
             </div>
             <div>Participate</div>
           </NavLink>
-        </Link>
+        </Link> */}
 
         <Link href="/dashboard/review">
           <NavLink selected={router.pathname === '/dashboard/review'}>


### PR DESCRIPTION
I created a dropdown filter for the Discover page that allows users to sort by studies they've participated in or have not participated in. I commented out the link in the Navbar for "Participate" in case we need it again. Of course, the page still exists. I also fixed the copy for the archive functionality, so that the text is all different if the study is already archived, i.e., "unarchive".